### PR TITLE
Correct existing user-created roles' feature sets

### DIFF
--- a/db/migrate/20150914202922_correct_user_created_role_feature_sets.rb
+++ b/db/migrate/20150914202922_correct_user_created_role_feature_sets.rb
@@ -1,0 +1,39 @@
+class CorrectUserCreatedRoleFeatureSets < ActiveRecord::Migration
+  class MiqUserRole < ActiveRecord::Base
+    has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features
+  end
+  class MiqProductFeature < ActiveRecord::Base
+  end
+
+  def up
+    vm_cloud_explorer = MiqProductFeature.find_by_identifier("vm_cloud_explorer")
+    vm_infra_explorer = MiqProductFeature.find_by_identifier("vm_infra_explorer")
+    instances = MiqProductFeature.find_by_identifier("instance")
+    images = MiqProductFeature.find_by_identifier("image")
+    vms = MiqProductFeature.find_by_identifier("vm")
+    templates = MiqProductFeature.find_by_identifier("miq_template")
+
+    affected_user_roles.each do |user_role|
+      if user_role.miq_product_features.include?(vm_cloud_explorer)
+        user_role.miq_product_features << instances
+        user_role.miq_product_features << images
+      end
+
+      if user_role.miq_product_features.include?(vm_infra_explorer)
+        user_role.miq_product_features << vms
+        user_role.miq_product_features << templates
+      end
+
+      user_role.save!
+    end
+  end
+
+  def down
+  end
+
+  def affected_user_roles
+    MiqUserRole
+      .includes(:miq_product_features)
+      .where(:read_only => false, :miq_product_features => {:identifier => %w(vm_cloud_explorer vm_infra_explorer)})
+  end
+end

--- a/spec/migrations/20150914202922_correct_user_created_role_feature_sets_spec.rb
+++ b/spec/migrations/20150914202922_correct_user_created_role_feature_sets_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+require_migration
+
+RSpec.describe CorrectUserCreatedRoleFeatureSets do
+  migration_context :up do
+    let(:user_role_stub) { migration_stub(:MiqUserRole) }
+    let(:product_feature_stub) { migration_stub(:MiqProductFeature) }
+
+    it "adds 'instance' and 'image' to user roles product features with 'vm_cloud_explorer'" do
+      instances = product_feature_stub.create!(
+        :name => "Instance Access Rules",
+        :description => "Access Rules for Instances",
+        :feature_type => "node",
+        :identifier => "instance"
+      )
+      images = product_feature_stub.create!(
+        :name => "Image Access Rules",
+        :description => "Access Rules for Images",
+        :feature_type => "node",
+        :identifier => "image"
+      )
+      vm_cloud_explorer = product_feature_stub.create!(
+        :name => "Instances",
+        :description => "Instance Views",
+        :feature_type => "node",
+        :identifier => "vm_cloud_explorer"
+      )
+      user_role = user_role_stub.create!(:miq_product_features => [vm_cloud_explorer], :read_only => false)
+
+      expect(user_role.miq_product_features).not_to include(instances)
+      expect(user_role.miq_product_features).not_to include(images)
+
+      migrate
+      user_role.reload
+
+      expect(user_role.miq_product_features).to include(instances)
+      expect(user_role.miq_product_features).to include(images)
+    end
+
+    it "adds 'vm' and 'miq_template' to user roles product features with 'vm_infra_explorer'" do
+      vms = product_feature_stub.create!(
+        :name => "VM Access Rules",
+        :description => "Access Rules for Virtual Machines",
+        :feature_type => "node",
+        :identifier => "vm"
+      )
+      templates = product_feature_stub.create!(
+        :name => "Template Access Rules",
+        :description => "Access Rules for Templates",
+        :feature_type => "node",
+        :identifier => "miq_template"
+      )
+      vm_infra_explorer = product_feature_stub.create!(
+        :name => "Virtual Machines",
+        :description => "Virtual Machine Views",
+        :feature_type => "node",
+        :identifier => "vm_infra_explorer"
+      )
+      user_role = user_role_stub.create!(:miq_product_features => [vm_infra_explorer], :read_only => false)
+
+      expect(user_role.miq_product_features).not_to include(vms)
+      expect(user_role.miq_product_features).not_to include(templates)
+
+      migrate
+      user_role.reload
+
+      expect(user_role.miq_product_features).to include(vms)
+      expect(user_role.miq_product_features).to include(templates)
+    end
+
+    it "leaves user roles with neither feature set alone" do
+      product_feature_stub.create!(
+        :name => "VM Access Rules",
+        :description => "Access Rules for Virtual Machines",
+        :feature_type => "node",
+        :identifier => "vm"
+      )
+      product_feature_stub.create!(
+        :name => "Template Access Rules",
+        :description => "Access Rules for Templates",
+        :feature_type => "node",
+        :identifier => "miq_template"
+      )
+      product_feature_stub.create!(
+        :name => "Virtual Machines",
+        :description => "Virtual Machine Views",
+        :feature_type => "node",
+        :identifier => "vm_infra_explorer"
+      )
+      user_role = user_role_stub.create!(:miq_product_features => [], :read_only => false)
+
+      expect { migrate }.not_to change { user_role.reload.miq_product_features }
+    end
+
+    it "leaves read only user roles alone" do
+      product_feature_stub.create!(
+        :name => "VM Access Rules",
+        :description => "Access Rules for Virtual Machines",
+        :feature_type => "node",
+        :identifier => "vm"
+      )
+      product_feature_stub.create!(
+        :name => "Template Access Rules",
+        :description => "Access Rules for Templates",
+        :feature_type => "node",
+        :identifier => "miq_template"
+      )
+      vm_infra_explorer = product_feature_stub.create!(
+        :name => "Virtual Machines",
+        :description => "Virtual Machine Views",
+        :feature_type => "node",
+        :identifier => "vm_infra_explorer"
+      )
+      user_role = user_role_stub.create!(:miq_product_features => [vm_infra_explorer], :read_only => true)
+
+      expect { migrate }.not_to change { user_role.reload.miq_product_features }
+    end
+  end
+end


### PR DESCRIPTION
Adds a migration to preserve any existing RBAC privileges after
restructuring the product feature tree.

Resolves https://trello.com/c/Yl99rzhD